### PR TITLE
fixes related to tidymodels/parsnip#382

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# poissonreg (development version)
+# poissonreg 0.1.0
+
+* Work-around for a `glmnet` bug where different column order will silently produce incorrect predictions. 
+
+* `multi_predict()` was enabled. 
+
+* Updates to go along with new version of `parsnip`. 
 
 # poissonreg 0.0.1
 

--- a/R/poisson_reg_data.R
+++ b/R/poisson_reg_data.R
@@ -251,7 +251,7 @@ make_poisson_reg <- function() {
       args =
         list(
           object = expr(object$fit),
-          newx = expr(as.matrix(new_data)),
+          newx = expr(as.matrix(new_data[, rownames(object$fit$beta)])),
           type = "response",
           s = expr(object$spec$args$penalty)
         )
@@ -269,7 +269,7 @@ make_poisson_reg <- function() {
       func = c(fun = "predict"),
       args =
         list(object = expr(object$fit),
-             newx = expr(as.matrix(new_data)))
+             newx = expr(as.matrix(new_data[, rownames(object$fit$beta)])))
     )
   )
 

--- a/tests/testthat/test-poisson-reg.R
+++ b/tests/testthat/test-poisson-reg.R
@@ -190,14 +190,6 @@ test_that('glm execution', {
     )
   )
 
-  glm_form_catch <- fit(
-    glm_spec,
-    y ~ x,
-    data = seniors,
-    control = caught_ctrl
-  )
-  expect_true(inherits(glm_form_catch$fit, "try-error"))
-
 })
 
 test_that('glm prediction', {


### PR DESCRIPTION
Previously...

``` r
library(tidymodels)
#> ── Attaching packages ────────────────────────────────────── tidymodels 0.1.1 ──
#> ✓ broom     0.7.0          ✓ recipes   0.1.14    
#> ✓ dials     0.0.9.9000     ✓ rsample   0.0.8.9000
#> ✓ dplyr     1.0.2          ✓ tibble    3.0.4     
#> ✓ ggplot2   3.3.2          ✓ tidyr     1.1.2     
#> ✓ infer     0.5.2          ✓ tune      0.1.1.9001
#> ✓ modeldata 0.0.2.9000     ✓ workflows 0.2.1.9000
#> ✓ parsnip   0.1.3.9000     ✓ yardstick 0.0.7     
#> ✓ purrr     0.3.4
#> ── Conflicts ───────────────────────────────────────── tidymodels_conflicts() ──
#> x purrr::discard() masks scales::discard()
#> x dplyr::filter()  masks stats::filter()
#> x dplyr::lag()     masks stats::lag()
#> x recipes::step()  masks stats::step()
library(poissonreg)

data("bioChemists", package = "pscl")

bioChemists <- dplyr::select(bioChemists, -fem, -mar)
```

``` r

log_lin_f <-
  poisson_reg(penalty = .1) %>%
  set_engine("glmnet") %>%
  fit(art ~ ., data = bioChemists)

log_lin_xy <-
  poisson_reg(penalty = .1) %>%
  set_engine("glmnet") %>%
  fit_xy(bioChemists[, -1], bioChemists$art)
```

``` r

all.equal(
  predict(log_lin_f, bioChemists[, 2:4]),
  predict(log_lin_f, bioChemists[, rev(2:4)])
)
#> [1] TRUE

all.equal(
  predict(log_lin_xy, bioChemists[, 2:4]),
  predict(log_lin_xy, bioChemists[, rev(2:4)])
)
#> [1] "Component \".pred\": Mean relative difference: 0.2883006"
```

<sup>Created on 2020-10-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Now: 

``` r
library(tidymodels)
#> ── Attaching packages ────────────────────────────────────── tidymodels 0.1.1 ──
#> ✓ broom     0.7.0          ✓ recipes   0.1.14    
#> ✓ dials     0.0.9.9000     ✓ rsample   0.0.8.9000
#> ✓ dplyr     1.0.2          ✓ tibble    3.0.4     
#> ✓ ggplot2   3.3.2          ✓ tidyr     1.1.2     
#> ✓ infer     0.5.2          ✓ tune      0.1.1.9001
#> ✓ modeldata 0.0.2.9000     ✓ workflows 0.2.1.9000
#> ✓ parsnip   0.1.3.9000     ✓ yardstick 0.0.7     
#> ✓ purrr     0.3.4
#> ── Conflicts ───────────────────────────────────────── tidymodels_conflicts() ──
#> x purrr::discard() masks scales::discard()
#> x dplyr::filter()  masks stats::filter()
#> x dplyr::lag()     masks stats::lag()
#> x recipes::step()  masks stats::step()
library(poissonreg)

data("bioChemists", package = "pscl")

bioChemists <- dplyr::select(bioChemists, -fem, -mar)
```

``` r

log_lin_f <-
  poisson_reg(penalty = .1) %>%
  set_engine("glmnet") %>%
  fit(art ~ ., data = bioChemists)

log_lin_xy <-
  poisson_reg(penalty = .1) %>%
  set_engine("glmnet") %>%
  fit_xy(bioChemists[, -1], bioChemists$art)
```

``` r

all.equal(
  predict(log_lin_f, bioChemists[, 2:4]),
  predict(log_lin_f, bioChemists[, rev(2:4)])
)
#> [1] TRUE

all.equal(
  predict(log_lin_xy, bioChemists[, 2:4]),
  predict(log_lin_xy, bioChemists[, rev(2:4)])
)
#> [1] TRUE
```

<sup>Created on 2020-10-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>