### PR TITLE
fix single-row predictions for glmnet

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,8 @@ jobs:
           - {os: ubuntu-20.04,   r: 'oldrel-1'}
           - {os: ubuntu-20.04,   r: 'oldrel-2'}
           - {os: ubuntu-20.04,   r: 'oldrel-3'}
-          - {os: ubuntu-20.04,   r: 'oldrel-4'}
+          # glmnet needs R >= 3.6.0
+          #- {os: ubuntu-20.04,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     tidyr
 Suggests: 
     covr,
+    glmnet,
     pscl,
     spelling,
     testthat (>= 3.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,22 +1,29 @@
 # poissonreg (development version)
 
+* Predictions for a single observation now work for `poisson_reg()` with the `"glmnet"` engine (#48).
+
+
 # poissonreg 1.0.1
 
 * Update to the .Rd files to generate valid HTML5
+
 
 # poissonreg 1.0.0
 
 * Changes for using case weights with parsnip 1.0.0.
 
+
 # poissonreg 0.2.0
 
 * Model definition functions (e.g. `poisson_reg()`) were moved to the parsnip package.
+
 
 # poissonreg 0.1.1
 
 * A default engine of `glm` was added for `poisson_reg()`. 
 
 * Added `tidy()` methods for `pscl::hurdle()` and `pscl::zeroinfl()`.
+
 
 # poissonreg 0.1.0
 
@@ -25,6 +32,7 @@
 * `multi_predict()` was enabled. 
 
 * Updates to go along with new version of `parsnip`. 
+
 
 # poissonreg 0.0.1
 

--- a/R/poisson_reg_data.R
+++ b/R/poisson_reg_data.R
@@ -247,7 +247,7 @@ make_poisson_reg <- function() {
       args =
         list(
           object = expr(object$fit),
-          newx = expr(as.matrix(new_data[, rownames(object$fit$beta)])),
+          newx = expr(as.matrix(new_data[, rownames(object$fit$beta), drop = FALSE])),
           type = "response",
           s = expr(object$spec$args$penalty)
         )
@@ -266,7 +266,7 @@ make_poisson_reg <- function() {
       args =
         list(
           object = expr(object$fit),
-          newx = expr(as.matrix(new_data[, rownames(object$fit$beta)]))
+          newx = expr(as.matrix(new_data[, rownames(object$fit$beta), drop = FALSE]))
         )
     )
   )

--- a/tests/testthat/test-poisson_reg-glmnet.R
+++ b/tests/testthat/test-poisson_reg-glmnet.R
@@ -1,0 +1,11 @@
+test_that("prediction of single row", {
+  m <- poisson_reg() %>%
+    set_engine("glmnet") %>%
+    fit(count ~ (.)^2, data = seniors[,2:4])
+
+  pred_1 <- predict(m, new_data = seniors[1,], penalty = 0.1)
+  expect_equal(nrow(pred_1), 1)
+
+  multi_pred_1 <- multi_predict(m, new_data = seniors[1,])
+  expect_equal(nrow(multi_pred_1), 1)
+})


### PR DESCRIPTION
closes #48 

``` r
library(poissonreg)
#> Loading required package: parsnip

m <- poisson_reg() %>% 
  set_engine("glmnet") %>% 
  fit(count ~ (.)^2, data = seniors[,2:4])

predict(m, new_data = seniors[1,], penalty = 0.1)
#> # A tibble: 1 × 1
#>   .pred
#>   <dbl>
#> 1  724.
multi_predict(m, new_data = seniors[1,])
#> # A tibble: 1 × 1
#>   .pred            
#>   <list>           
#> 1 <tibble [72 × 2]>
```

<sup>Created on 2022-12-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>