### PR TITLE
Remove conditional generic for `predict_raw()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Predictions for a single observation now work for `poisson_reg()` with the `"glmnet"` engine (#48).
 
+* Removed the now obsolete registration of the `predict_raw()` generic as it is now exported from parnsip (#52).
+
 
 # poissonreg 1.0.1
 

--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -13,12 +13,3 @@ utils::globalVariables(
 )
 
 # nocov end
-
-# ------------------------------------------------------------------------------
-# The generic for predict_raw is not exported so make one here (if needed)
-
-if (!any(getNamespaceExports("parsnip") == "predict_raw")) {
-  predict_raw <- function(object, ...) {
-    UseMethod("predict_raw")
-  }
-}


### PR DESCRIPTION
it was exported in the dev [version 0.1.0.9001](https://github.com/tidymodels/parsnip/commit/7875931eb3e6d94d98975f0336fa50d46ea73916) and poissonreg depends on > 0.2.0