### PR TITLE
Article dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Suggests:
     spelling,
     testthat (>= 3.0.0)
 Config/Needs/website: 
-    rmarkdown,
     tidymodels,
     tidyverse/tidytemplate
 Config/testthat/edition: 3


### PR DESCRIPTION
For other pkgdown sites, we don't need `ramarkdown` in `Config/Needs/website: ` 