### PR TITLE
Update `rstanarm` function for predictions of `type = "conf_int"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * Tests are now self-contained (#60).
 
+* Predictions of type `"conf_int"` for the `"stan"` engine now use the function suggested by rstanarm (#86).
+
 
 # poissonreg 1.0.1
 

--- a/R/poisson_reg-data.R
+++ b/R/poisson_reg-data.R
@@ -370,12 +370,11 @@ make_poisson_reg_stan <- function() {
       post = function(results, object) {
         organize_stan_interval(results, object, interval_type = "conf")
       },
-      func = c(pkg = "rstanarm", fun = "posterior_linpred"),
+      func = c(pkg = "rstanarm", fun = "posterior_epred"),
       args =
         list(
           object = expr(object$fit),
           newdata = expr(new_data),
-          transform = TRUE,
           seed = expr(sample.int(10^5, 1))
         )
     )


### PR DESCRIPTION
closes #80 