### PR TITLE
Remove obsolete check on `newdata`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * Predictions of type `"conf_int"` for the `"stan"` engine now use the function suggested by rstanarm (#86).
 
+* Removed obsolte check on supplying `newdata` as an argument to `predict()` or `multi_predict()` (#87).
+
 
 # poissonreg 1.0.1
 

--- a/R/poisson_reg-glmnet.R
+++ b/R/poisson_reg-glmnet.R
@@ -26,10 +26,6 @@
 #' @export
 predict._fishnet <-
   function(object, new_data, type = NULL, opts = list(), penalty = NULL, multi = FALSE, ...) {
-    if (any(names(enquos(...)) == "newdata")) {
-      rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-    }
-
     # See discussion in https://github.com/tidymodels/parsnip/issues/195
     if (is.null(penalty) & !is.null(object$spec$args$penalty)) {
       penalty <- object$spec$args$penalty
@@ -43,10 +39,6 @@ predict._fishnet <-
 
 #' @export
 predict_numeric._fishnet <- function(object, new_data, ...) {
-  if (any(names(enquos(...)) == "newdata")) {
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-  }
-
   object$spec <- parsnip::eval_args(object$spec)
   parsnip::predict_numeric.model_fit(object, new_data = new_data, ...)
 }
@@ -65,10 +57,6 @@ predict_numeric._fishnet <- function(object, new_data, ...) {
 #' @export
 #' @keywords internal
 predict_raw._fishnet <- function(object, new_data, opts = list(), ...) {
-  if (any(names(enquos(...)) == "newdata")) {
-    rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-  }
-
   object$spec <- parsnip::eval_args(object$spec)
   opts$s <- object$spec$args$penalty
   parsnip::predict_raw.model_fit(object, new_data = new_data, opts = opts, ...)

--- a/R/poisson_reg-glmnet.R
+++ b/R/poisson_reg-glmnet.R
@@ -69,10 +69,6 @@ predict_raw._fishnet <- function(object, new_data, opts = list(), ...) {
 #' @param penalty A numeric vector of penalty values.
 multi_predict._fishnet <-
   function(object, new_data, type = NULL, penalty = NULL, ...) {
-    if (any(names(enquos(...)) == "newdata")) {
-      rlang::abort("Did you mean to use `new_data` instead of `newdata`?")
-    }
-
     dots <- list(...)
 
     object$spec <- eval_args(object$spec)


### PR DESCRIPTION
This follows the logic of https://github.com/tidymodels/parsnip/pull/879 for the `predict()` methods. For `multi_predict()` it follows https://github.com/tidymodels/parsnip/pull/912.

This then also closes #76.

The tests in `extratests` `test-glmnet-poisson.R` also run fine.